### PR TITLE
Import UIKit to fix build error with Swift Package Manager

### DIFF
--- a/Sources/AppstoreTransition/CardDetailViewController.swift
+++ b/Sources/AppstoreTransition/CardDetailViewController.swift
@@ -141,7 +141,7 @@ public final class CardDismissHandler: NSObject {
     // This handles both screen edge and dragdown pan. As screen edge pan is a subclass of pan gesture, this input param works.
     @objc func handleDismissalPan(gesture: UIPanGestureRecognizer) {
         
-        let velocity = gesture.velocity(in: source.view)
+//        let velocity = gesture.velocity(in: source.view)
         //if velocity.y > 0 { return }
         
         let isScreenEdgePan = gesture.isKind(of: DismissalScreenEdgePanGesture.self)

--- a/Sources/AppstoreTransition/DismissCardAnimator.swift
+++ b/Sources/AppstoreTransition/DismissCardAnimator.swift
@@ -37,7 +37,7 @@ final class DismissCardAnimator: NSObject, UIViewControllerAnimatedTransitioning
         let ctx = transitionContext
         let container = ctx.containerView
         
-        var toViewController: CardsViewController! = ctx.viewController(forKey: .to)?.cardsViewController()
+        let toViewController: CardsViewController! = ctx.viewController(forKey: .to)?.cardsViewController()
         
         let screens: (cardDetail: CardDetailViewController, home: CardsViewController) = (
             ctx.viewController(forKey: .from)! as! CardDetailViewController,

--- a/Sources/AppstoreTransition/PresentCardAnimator.swift
+++ b/Sources/AppstoreTransition/PresentCardAnimator.swift
@@ -91,7 +91,7 @@ final class PresentCardTransitionDriver {
     init(params: PresentCardAnimator.Params, transitionContext: UIViewControllerContextTransitioning, baseAnimator: UIViewPropertyAnimator) {
         let ctx = transitionContext
         let container = ctx.containerView
-        var fromViewController: CardsViewController! = ctx.viewController(forKey: .from)?.cardsViewController()
+        let fromViewController: CardsViewController! = ctx.viewController(forKey: .from)?.cardsViewController()
         
         let screens: (home: CardsViewController, cardDetail: CardDetailViewController) = (
             fromViewController,
@@ -138,8 +138,6 @@ final class PresentCardTransitionDriver {
         
         animatedContainerView.addSubview(cardDetailView)
         cardDetailView.translatesAutoresizingMaskIntoConstraints = false
-        
-        let weirdCardToAnimatedContainerTopAnchor: NSLayoutConstraint
         
         do /* Pin top (or center Y) and center X of the card, in animated container view */ {
             let verticalAnchor: NSLayoutConstraint = {

--- a/Sources/AppstoreTransition/UIView+Extension.swift
+++ b/Sources/AppstoreTransition/UIView+Extension.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 appssemble. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 extension UIView {
 

--- a/Sources/AppstoreTransition/UIViewController+Extension.swift
+++ b/Sources/AppstoreTransition/UIViewController+Extension.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 appssemble. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 public extension UIViewController {
     


### PR DESCRIPTION
When using Swift Package Manager to use this project in another one, two files had build errors. These were UIKit extension files that imported Foundation but not UIKit.

Additionally, this changeset fixes some build warnings (var vs. let, unused variables, etc.).